### PR TITLE
Improve test coverage

### DIFF
--- a/djqscsv/djqscsv.py
+++ b/djqscsv/djqscsv.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 from django.conf import settings
 if not settings.configured:
     # required to import ValuesQuerySet
-    settings.configure()
+    settings.configure() # pragma: no cover
 
 from django.db.models.query import ValuesQuerySet
 
@@ -63,6 +63,8 @@ def write_csv(queryset, file_obj, field_header_map=None,
     try:
         field_names = values_qs.field_names
     except AttributeError:
+        # in django1.5, empty querysets trigger
+        # this exception, but not django 1.6
         raise CSVException("Empty queryset provided to exporter.")
 
     # verbose_name defaults to the raw field name, so in either case

--- a/test_app/djqscsv_tests/tests.py
+++ b/test_app/djqscsv_tests/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
+from django import VERSION as DJANGO_VERSION
+
 import csv
 
 from StringIO import StringIO
@@ -151,3 +153,15 @@ class WriteCSVDataTests(TestCase):
         self.assertEqual(response['Content-Type'], 'text/csv')
         self.assertMatchesCsv(response.content.split('\n'),
                               self.full_csv)
+
+    def test_empty_queryset(self):
+        qs = self.qs.none()
+        obj = StringIO()
+        if DJANGO_VERSION[:2] == (1, 5):
+            with self.assertRaises(djqscsv.CSVException):
+                djqscsv.write_csv(qs, obj)
+        elif DJANGO_VERSION[:2] == (1, 6):
+            djqscsv.write_csv(qs, obj, use_verbose_names=False)
+            self.assertEqual(obj.getvalue(),
+                             '\xef\xbb\xbfid,name,address,info\r\n')
+


### PR DESCRIPTION
Don't test initialization code because it isn't relevant possible to trigger this in the test environment.

Test empty querysets.
