### PR TITLE
Force verbose_name to be a unicode object

### DIFF
--- a/djqscsv/djqscsv.py
+++ b/djqscsv/djqscsv.py
@@ -72,7 +72,7 @@ def write_csv(queryset, file_obj, field_header_map=None,
     # verbose_name defaults to the raw field name, so in either case
     # this will produce a complete mapping of field names to column names
     if use_verbose_names:
-        name_map = {field.name: field.verbose_name
+        name_map = {field.name: unicode(field.verbose_name)
                     for field in queryset.model._meta.fields
                     if field.name in field_names}
     else:


### PR DESCRIPTION
In some cases, <queryset_instance>.model._meta.fields.verbose_name is
a unicode object as expected, like:
'name' or 'Name of User'

but other in cases, it is a python object representation, like:
<django.utils.functional.__proxy__ object at 0xb2a82bac>

It is unclear why this is happening, but it turned up when trying to
export just the column headers of an empty queryset. By calling unicode,
it is forced to be the desired unicode object.
