### PR TITLE
Added support for aggregated fields in CSV output.

### DIFF
--- a/djqscsv/djqscsv.py
+++ b/djqscsv/djqscsv.py
@@ -90,6 +90,10 @@ def write_csv(queryset, file_obj, **kwargs):
     if extra_columns:
         field_names += extra_columns
 
+    aggregate_columns = list(values_qs.query.aggregate_select)
+    if aggregate_columns:
+        field_names += aggregate_columns
+
     if field_order:
         # go through the field_names and put the ones
         # that appear in the ordering list first


### PR DESCRIPTION
If you have an aggregated field in your queryset, such as with:

```
Publisher.objects.annotate(num_books=Count('book'))
```

Trying to include this column 'num_books' in your CSV output results in a ValueError Exception with the error `dict contains fields not in fieldnames: num_books`.  This fixes that by looking for column names for aggregates in the queryset.query, just like for extra columns.
