### PR TITLE
Fixing UnicodeEncodeError on localized field `verbose_name`.

### DIFF
--- a/djqscsv/djqscsv.py
+++ b/djqscsv/djqscsv.py
@@ -110,7 +110,7 @@ def write_csv(queryset, file_obj, **kwargs):
     name_map = dict((field, field) for field in field_names)
     if use_verbose_names:
         name_map.update(
-            dict((field.name, unicode(field.verbose_name))
+            dict((field.name, field.verbose_name.encode('utf-8'))
                  for field in queryset.model._meta.fields
                  if field.name in field_names))
 


### PR DESCRIPTION
I think the problem is because i have an verbose_name translate to `Título`, and the `djqscsv` is not dealing right with it.

I am receiving an error when I try to export some queryset, so I encoded the `verbose_name` after the `write_csv` and it fixed.

```
Environment:


Request Method: GET
Request URL: http://myurl/export/

Django Version: 1.7.4
Python Version: 2.7.3
Installed Applications:
['deck',
 'core',
 'jury',
 'activelink',
 'django_extensions',
 'vanilla',
 'bootstrap3',
 'allauth',
 'allauth.account',
 'allauth.socialaccount',
 'allauth.socialaccount.providers.google',
 'allauth.socialaccount.providers.github',
 'allauth.socialaccount.providers.facebook',
 'debug_toolbar',
 'datetimewidget',
 'raven.contrib.django.raven_compat',
 'django.contrib.admin',
 'django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.messages',
 'django.contrib.staticfiles',
 'django.contrib.sites']
Installed Middleware:
('django.contrib.auth.backends.ModelBackend',
 'django.middleware.common.CommonMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware')


Traceback:
File "/home/virtualenv/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/virtualenv/local/lib/python2.7/site-packages/django/views/generic/base.py" in view
  69.             return self.dispatch(request, *args, **kwargs)
File "/home/virtualenv/local/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapper
  29.             return bound_func(*args, **kwargs)
File "/home/virtualenv/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
  21.                 return view_func(request, *args, **kwargs)
File "/home/virtualenv/local/lib/python2.7/site-packages/django/utils/decorators.py" in bound_func
  25.                 return func.__get__(self, type(self))(*args2, **kwargs2)
File "./deck/views.py" in dispatch
  118.         return super(ExportEvent, self).dispatch(*args, **kwargs)
File "/home/virtualenv/local/lib/python2.7/site-packages/django/views/generic/base.py" in dispatch
  87.         return handler(request, *args, **kwargs)
File "./deck/views.py" in get
  133.             field_header_map=field_header_map
File "/home/virtualenv/local/lib/python2.7/site-packages/djqscsv/djqscsv.py" in render_to_csv_response
  49.     write_csv(queryset, response, **kwargs)
File "/home/virtualenv/local/lib/python2.7/site-packages/djqscsv/djqscsv.py" in write_csv
  122.     writer.writerow(merged_header_map)
File "/usr/lib/python2.7/csv.py" in writerow
  148.         return self.writer.writerow(self._dict_to_list(rowdict))

Exception Type: UnicodeEncodeError at /myurl/export/
Exception Value: 'ascii' codec can't encode character u'\xed' in position 1: ordinal not in range(128)
```