### PR TITLE
Update to support Django 1.9 ValuesIterable

### DIFF
--- a/djqscsv/djqscsv.py
+++ b/djqscsv/djqscsv.py
@@ -10,7 +10,9 @@ if not settings.configured:
     # required to import ValuesQuerySet
     settings.configure()  # pragma: no cover
 
-from django.db.models.query import ValuesQuerySet
+from django.db.models import query
+if not hasattr(query, "ValuesIterable"): # Fall back for old versions of django
+    query.ValuesIterable = query.ValuesQuerySet
 
 from django.utils import six
 
@@ -74,7 +76,7 @@ def write_csv(queryset, file_obj, **kwargs):
 
     # the CSV must always be built from a values queryset
     # in order to introspect the necessary fields.
-    if isinstance(queryset, ValuesQuerySet):
+    if isinstance(queryset, query.ValuesIterable):
         values_qs = queryset
     else:
         values_qs = queryset.values()


### PR DESCRIPTION
Removes direct dependency on importing queryset which fixes Django 1.9 compatibilty

Related though, due to different way of retrieving fieldnames (as ValuesIterable is literally a queryset now) have just removed the ability to add verbose_names for all fields (just returning them for current model's fields), this could use some work