### PR TITLE
Change render_to_csv_response to return a StreamingHttpResponse by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.5
 env:
-  - DJANGO=1.5
-  - DJANGO=1.6
-  - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
+  - DJANGO=1.10
 matrix:
   exclude:
-    - python: 2.6
-      env: DJANGO=1.6
-    - python: 2.6
-      env: DJANGO=1.7
-    - python: 2.6
-      env: DJANGO=1.8
-    - python: 2.6
-      env: DJANGO=1.9
-    - python: 3.5
-      env: DJANGO=1.5
     - python: 3.5
       env: DJANGO=1.6
     - python: 3.5

--- a/README.rst
+++ b/README.rst
@@ -27,13 +27,13 @@ installation
 Run::
 
    pip install django-queryset-csv
-   
-Supports Python 2.6 and 2.7, Django >= 1.5.
+
+Supports Python 2.7 and 3.5, Django >= 1.8.
 
 usage
 -----
 Perform all filtering and field authorization in your view using ``.filter()`` and ``.values()``.
-Then, use ``render_to_csv_response`` to turn a queryset into a respone with a CSV attachment.
+Then, use ``render_to_csv_response`` to turn a queryset into a response with a CSV attachment.
 Pass it a ``QuerySet`` or ``ValuesQuerySet`` instance::
 
   from djqscsv import render_to_csv_response
@@ -41,6 +41,14 @@ Pass it a ``QuerySet`` or ``ValuesQuerySet`` instance::
   def csv_view(request):
     qs = Foo.objects.filter(bar=True).values('id', 'bar')
     return render_to_csv_response(qs)
+
+If you need to write the CSV to a file you can use ``write_csv`` instead::
+
+  from djqscsv import write_csv
+
+  qs = Foo.objects.filter(bar=True).values('id', 'bar')
+  with open('foo.csv', 'w') as csv_file:
+    write_csv(qs, csv_file)
 
 foreign keys
 ------------
@@ -76,6 +84,10 @@ This module exports two functions that write CSVs, ``render_to_csv_response`` an
 - ``field_serializer_map`` - (default: ``{}``) A dictionary mapping names of model fields to functions that serialize them to text. For example, ``{'created': (lambda x: x.strftime('%Y/%m/%d')) }`` will serialize a datetime field called ``created``.
 - ``use_verbose_names`` - (default: ``True``) A boolean determining whether to use the django field's ``verbose_name``, or to use it's regular field name as a column header. Note that if a given field is found in the ``field_header_map``, this value will take precendence.
 - ``field_order`` - (default: ``None``) A list of fields to determine the sort order. This list need not be complete: any fields not specified will follow those in the list with the order they would have otherwise used.
+
+In addition to the above arguments, ``render_to_csv_response`` takes the following optional keyword argument:
+
+- ``streaming`` - (default: ``True``) A boolean determining whether to use ``StreamingHttpResponse`` instead of the normal ``HttpResponse``.
 
 The remaining keyword arguments are *passed through* to the csv writer. For example, you can export a CSV with a different delimiter.
 

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "Framework :: Django",
         "License :: OSI Approved :: GNU General Public License (GPL)"
     ],
-    install_requires=['django>=1.5', 'unicodecsv>=0.14.1'],
+    install_requires=['django>=1.8', 'unicodecsv>=0.14.1'],
 )

--- a/test_app/djqscsv_tests/tests/test_csv_creation.py
+++ b/test_app/djqscsv_tests/tests/test_csv_creation.py
@@ -298,8 +298,9 @@ class RenderToCSVResponseTests(CSVTestCase):
         response = djqscsv.render_to_csv_response(self.qs,
                                                   use_verbose_names=False)
         self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertMatchesCsv(response.content.splitlines(),
-                              self.FULL_PERSON_CSV_NO_VERBOSE)
+        self.assertMatchesCsv(
+            b''.join(response.streaming_content).splitlines(),
+            self.FULL_PERSON_CSV_NO_VERBOSE)
 
         self.assertRegexpMatches(response['Content-Disposition'],
                                  r'attachment; filename=person_export.csv;')
@@ -308,6 +309,16 @@ class RenderToCSVResponseTests(CSVTestCase):
         response = djqscsv.render_to_csv_response(self.qs,
                                                   filename="test_csv",
                                                   use_verbose_names=False)
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertMatchesCsv(
+            b''.join(response.streaming_content).splitlines(),
+            self.FULL_PERSON_CSV_NO_VERBOSE)
+
+    def test_render_to_csv_response_non_streaming(self):
+        response = djqscsv.render_to_csv_response(self.qs,
+                                                  filename="test_csv",
+                                                  use_verbose_names=False,
+                                                  streaming=False)
         self.assertEqual(response['Content-Type'], 'text/csv')
         self.assertMatchesCsv(response.content.splitlines(),
                               self.FULL_PERSON_CSV_NO_VERBOSE)
@@ -319,9 +330,10 @@ class RenderToCSVResponseTests(CSVTestCase):
                                                   delimiter='|')
 
         self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertMatchesCsv(response.content.splitlines(),
-                              self.FULL_PERSON_CSV_NO_VERBOSE,
-                              delimiter="|")
+        self.assertMatchesCsv(
+            b''.join(response.streaming_content).splitlines(),
+            self.FULL_PERSON_CSV_NO_VERBOSE,
+            delimiter="|")
 
     def test_render_to_csv_fails_on_delimiter_mismatch(self):
         response = djqscsv.render_to_csv_response(self.qs,
@@ -330,5 +342,6 @@ class RenderToCSVResponseTests(CSVTestCase):
                                                   delimiter='|')
 
         self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertNotMatchesCsv(response.content.splitlines(),
-                                 self.FULL_PERSON_CSV_NO_VERBOSE)
+        self.assertNotMatchesCsv(
+            b''.join(response.streaming_content).splitlines(),
+            self.FULL_PERSON_CSV_NO_VERBOSE)


### PR DESCRIPTION
Change `render_to_csv_response` to return a `StreamingHttpResponse` instead of a normal `HttpResponse`.
The old behaviour is available by setting the keyword argument `streaming` to `False`.

This is technically a breaking change, as [some middlewares do not work with `StreamingHttpResponse`](https://docs.djangoproject.com/en/1.9/ref/request-response/#streaminghttpresponse-objects).

Also drops support for Python 2.6 and Django 1.5, and cleans up the README a bit.

Fixes #86, Fixes #87