### PR TITLE
Add PyPI publishing support to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
+
+sudo: false
+
 python:
   - 2.7
   - 3.5
+
 env:
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+
 matrix:
   exclude:
     - python: 3.5
@@ -13,13 +18,24 @@ matrix:
     - python: 3.5
       env: DJANGO=1.7
 
-
 install:
   - pip install -q Django==$DJANGO
   - pip install -r dev_requirements.txt
   - python setup.py install
+
 script:
   - coverage run --source=djqscsv test_app/manage.py test djqscsv_tests
   - flake8 --exclude=migrations djqscsv/ test_app/
+
 after_success:
   - coveralls
+
+deploy:
+  provider: pypi
+  user: azavea
+  password:
+    secure: Wb3ow0qdnjFsdIoC2Lvke0Rp6h40WNDkp4Fuyltd0ex2MQMglNo1qHZYlhQvJ/5q7pHEAO7pIqOMzOQ1mls9Za1/AoolEl3zm9b3oW86bAR8AVS/UdCUkkCmPaO+0VsYCt63McaLFA0xQnWxA7kZUkfEeS7RBhT63f+diPqg2fU=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    repo: azavea/django-queryset-csv


### PR DESCRIPTION
When tagged commits go through the Travis CI workflow, package everything up and publish it on PyPI.

Aids in resolving https://github.com/azavea/django-queryset-csv/issues/88.