### PR TITLE
Add Django 1.11 to the Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
+  - DJANGO=1.11
 
 matrix:
   exclude:


### PR DESCRIPTION
Start testing the latest Django LTS version.

---

##### Testing

Travis successfully built with Django 1.11

https://travis-ci.org/azavea/django-queryset-csv/builds/249736353

---

Connects to https://github.com/OpenTreeMap/otm-core/issues/3156