### PR TITLE
Declare to PyPI and tools that djqscsv supports Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Environment :: Plugins",
         "Framework :: Django",
         "License :: OSI Approved :: GNU General Public License (GPL)"


### PR DESCRIPTION
We add the "trove classifiers" matching the versions listed in the TravisCI
build matrix so that tools like `caniusepython3` will list the library as
supported.

https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3

Connects to https://github.com/OpenTreeMap/otm-core/issues/3278